### PR TITLE
Add Dependabot configuration for detected ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+---
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "."
+  schedule:
+    interval: weekly
+    day: monday
+    time: '09:00'
+  open-pull-requests-limit: 10
+  assignees:
+  - javiyt
+  reviewers:
+  - javiyt
+  ignore:
+  - dependency-name: "*"
+    update-types:
+    - version-update:semver-patch
+- package-ecosystem: github-actions
+  directory: ".github/workflows"
+  schedule:
+    interval: weekly
+    day: monday
+    time: '09:00'
+  open-pull-requests-limit: 10
+  assignees:
+  - javiyt
+  reviewers:
+  - javiyt
+  ignore:
+  - dependency-name: "*"
+    update-types:
+    - version-update:semver-patch


### PR DESCRIPTION
This PR adds a Dependabot configuration file (`.github/dependabot.yml`) for the detected ecosystems:
- gomod (directory: `.`)
- github-actions (directory: `.github/workflows`)

The configuration includes:
- Weekly updates on Mondays at 09:00
- Automatic assignment to @javiyt as assignee and reviewer
- Ignore patch updates by default (to reduce noise)

You can customize this file further after merging.

Automated change via a script.
